### PR TITLE
Fix master race

### DIFF
--- a/src/crosstab.js
+++ b/src/crosstab.js
@@ -429,6 +429,12 @@
     }
 
     function unload() {
+        // Let it go, cease fighting when dying.
+        /* Object.values(util.eventTypes)
+            // except for `tabClosed` event, which triggers master tab election
+            .filter((event) => event !== util.eventTypes.tabClosed)
+            .forEach((event) => eventHandler.removeListener(event)); */
+
         crosstab.stopKeepalive = true;
         var numTabs = 0;
         util.forEach(util.tabs, function (tab, key) {


### PR DESCRIPTION
In some cases, master tab being closed is not completely dead,
listening to `tabPromted` event, it would try to compete to be master,
and then die. All other keepAlive functions carried out by master
would fall into void.

This commit will remove non-essential listener on unload.